### PR TITLE
chore: bump CI to node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
           cache: "pnpm"
       - run: pnpm install
       - run: pnpm lint


### PR DESCRIPTION
It seems the corepack it uses needs `>=18`, so we may as well bump to 20.x at least.


