### PR TITLE
fix: settle pending calls when `flush` runs them early

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -137,13 +137,22 @@ export function debounce<ArgumentsT extends unknown[], ReturnT>(
   };
 
   debounced.flush = () => {
-    _clearTimeout(timeout);
     if (!trailingArgs || currentPromise) {
+      // Nothing to flush — leave the pending timeout alone so the calls
+      // already waiting on it still resolve on schedule.
       return;
     }
+    _clearTimeout(timeout);
     const args = trailingArgs;
     trailingArgs = null;
-    return applyFn(this, args);
+    const promise = applyFn(this, args);
+    // The timeout that would have resolved these is gone, so hand them the
+    // flushed call's result instead of leaving them pending forever.
+    for (const _resolve of resolveList) {
+      _resolve(promise);
+    }
+    resolveList = [];
+    return promise;
   };
 
   return debounced;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -6,6 +6,13 @@ import { debounce } from "../src";
 
 const fixture = "fixture";
 
+// Guards against a promise that never settles: without it a stranded call
+// would hang the test until vitest's timeout rather than failing on the spot.
+const rejectAfter = async (ms: number) => {
+  await delay(ms);
+  throw new Error(`promise did not settle within ${ms}ms`);
+};
+
 test.concurrent("single call", async () => {
   const debounced = debounce(async (value) => value, 100);
   expect(await debounced(fixture)).toBe(fixture);
@@ -134,6 +141,35 @@ test("flush method of debounced with immediate call", async () => {
 
   expect(fn).toHaveBeenCalledTimes(1);
   expect(fn).toHaveBeenCalledWith(3);
+});
+
+test("flush resolves the promises of the calls it flushes", async () => {
+  const fn = vi.fn(async (value: number) => {
+    await delay(50);
+    return value * 2;
+  });
+  const debounced = debounce(fn, 100);
+
+  const promises = [1, 2, 3].map((value) => debounced(value));
+
+  await debounced.flush();
+
+  await expect(
+    Promise.race([Promise.all(promises), rejectAfter(300)]),
+  ).resolves.toMatchObject([6, 6, 6]);
+  expect(fn).toHaveBeenCalledTimes(1);
+});
+
+test("flush does not strand pending calls when there is nothing to flush", async () => {
+  const fn = vi.fn(async (value: number) => value * 2);
+  const debounced = debounce(fn, 100, { trailing: false });
+
+  const promise = debounced(1);
+
+  expect(debounced.flush()).toBeUndefined();
+
+  await expect(Promise.race([promise, rejectAfter(300)])).resolves.toBe(2);
+  expect(fn).toHaveBeenCalledTimes(1);
 });
 
 test("isPending method of debounced", async () => {


### PR DESCRIPTION
### Problem

`flush()` clears the debounce timeout as its very first statement, but the timeout callback is the only place that ever walks `resolveList`. Every caller already awaiting that timeout is left pending forever — even though `flush` goes on to call `fn` with exactly their arguments:

```js
const debounced = debounce(async (v) => v, 100);

const p = debounced(1);
debounced.flush();

await p; // never settles, although fn already ran with 1
```

The same clear-first ordering also breaks the early-return path. With `trailing: false` there are no `trailingArgs`, so a `flush()` between the call and the timeout firing kills the timeout and returns — the pending call is never invoked at all, and its promise never settles either:

```js
const debounced = debounce(async (v) => v * 2, 100, { trailing: false });

const p = debounced(1);
debounced.flush(); // undefined

await p; // never settles, and fn was never called
```

This is easy to hit in the common "flush on unmount / before save" pattern, where the flush happens while a debounced call is still in flight and the caller `await`s the returned promise.

### Fix

Move `_clearTimeout(timeout)` below the early return so a no-op `flush()` leaves the scheduled timeout intact, and resolve `resolveList` with the flushed promise when a flush does happen — those callers asked for exactly the invocation that just ran, so they get its result.

`flush()`'s return value is unchanged, and `cancel()` keeps its existing semantics (it deliberately drops the pending calls).

### Validation

- Two new tests, one per path; both fail on `main` and pass with the fix. Each races the pending promise against a timer so a regression fails immediately instead of hanging until vitest's timeout.
- `vitest run`: 13 passed. `pnpm lint` (eslint + prettier) and `tsc --noEmit` clean.

Related to #40, which reports surprising `flush` behaviour from the same code path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `flush()` behavior so pending calls are preserved when there is nothing to invoke immediately.
  * Flushed trailing calls now complete immediately and consistently resolve all queued callers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->